### PR TITLE
feat: migra autorizacion de fases 2/3 en Referidos a permiso dinamico

### DIFF
--- a/seed_permiso_referidos_autorizar.sql
+++ b/seed_permiso_referidos_autorizar.sql
@@ -1,0 +1,33 @@
+-- =============================================================
+-- SEED: Permiso "Referidos: Autorizar" (sub-permiso de Referidos)
+-- Reemplaza el hardcode `fkrol === 1 || fkrol === 7` (que asumia
+-- erroneamente que el rol 7 era Auxiliar Administrativa) usado para
+-- decidir quien puede aprobar las fases 2/3 y otras acciones de
+-- administrador dentro de Referidos. Ejecutar UNA SOLA VEZ.
+-- =============================================================
+
+-- 1. Insertar el permiso (orden = siguiente disponible, sin hardcodear numero)
+INSERT INTO permiso (nombre, descripcion, ruta, icono, orden)
+SELECT
+  'Referidos: Autorizar',
+  'Aprobar fases 2 y 3, editar/eliminar cualquier referido y gestionar documentos como administrador',
+  'referidos-autorizar',
+  'fa-check-double',
+  COALESCE(MAX(orden), 0) + 1
+FROM permiso
+ON CONFLICT (ruta) DO NOTHING;
+
+-- 2. Asignar por nombre de rol (no por ID, que cambia entre entornos)
+INSERT INTO rol_permiso (fkrol, fkpermiso)
+SELECT r.idrol, p.idpermiso FROM rol r, permiso p
+WHERE p.ruta = 'referidos-autorizar' AND r.nombre IN ('Administrador', 'Sistemas', 'Auxiliar Administrativa')
+ON CONFLICT DO NOTHING;
+
+-- Verificar resultado
+SELECT r.nombre AS rol, STRING_AGG(p.ruta, ', ') AS permisos
+FROM rol r
+JOIN rol_permiso rp ON r.idrol = rp.fkrol
+JOIN permiso p ON rp.fkpermiso = p.idpermiso
+WHERE p.ruta = 'referidos-autorizar'
+GROUP BY r.nombre
+ORDER BY r.nombre;

--- a/src/controllers/usuarioController.js
+++ b/src/controllers/usuarioController.js
@@ -1,9 +1,21 @@
 const usuarioService = require('../services/usuarioService');
 const { conAuditoria } = require('../utils/auditoria.helper');
+const { prisma } = require('../config/prisma');
+
+// Por nombre de rol, no por ID: el idrol de cada uno cambia entre entornos
+// e incluso entre momentos distintos del mismo entorno.
+const ROLES_VEN_INACTIVOS = ['Administrador', 'Sistemas', 'Auxiliar Administrativa'];
 
 const obtenerUsuarios = async (req, res) => {
     try{
-        const incluirInactivos = req.query.includeInactive === 'true' && (req.usuario.fkrol === 1 || req.usuario.fkrol === 4 || req.usuario.fkrol === 7);
+        let incluirInactivos = false;
+        if (req.query.includeInactive === 'true') {
+            const solicitante = await prisma.usuario.findUnique({
+                where: { idusuario: req.usuario.idusuario },
+                include: { rol: { select: { nombre: true } } }
+            });
+            incluirInactivos = ROLES_VEN_INACTIVOS.includes(solicitante?.rol?.nombre);
+        }
         const resultado = await usuarioService.obtenerUsuarios(!incluirInactivos);
 
         if(resultado.success){
@@ -170,7 +182,11 @@ const actualizarPerfil = async (req, res) => {
         const updateData = req.body;
         const usuario = req.usuario?.usuario || 'sistema';
 
-        if (req.usuario.fkrol !== 1) {
+        const solicitante = await prisma.usuario.findUnique({
+            where: { idusuario: req.usuario.idusuario },
+            include: { rol: { select: { nombre: true } } }
+        });
+        if (solicitante?.rol?.nombre !== 'Administrador') {
             delete updateData.fkrol;
         }
 

--- a/src/middlewares/checkPermiso.js
+++ b/src/middlewares/checkPermiso.js
@@ -31,6 +31,41 @@ async function esRolSuperadmin(fkrol) {
 }
 
 /**
+ * Verifica si un rol (por fkrol) tiene acceso a una ruta de permiso.
+ * Reutilizable tanto en middlewares de Express como en services (sin req/res).
+ * @param {number} fkrol
+ * @param {string} rutaPagina - Ruta de la página en la tabla permiso (ej: 'inventario')
+ */
+const tienePermiso = async (fkrol, rutaPagina) => {
+  if (!fkrol) return false;
+
+  // Superadmin: acceso total (resuelto por nombre de rol, con cache)
+  if (await esRolSuperadmin(fkrol)) return true;
+
+  // Revisar caché
+  const cacheKey = `${fkrol}:${rutaPagina}`;
+  const cached = _cache.get(cacheKey);
+  if (cached && cached.expires > Date.now()) {
+    return cached.tieneAcceso;
+  }
+
+  // Consultar BD: ¿tiene este rol permiso para esta página?
+  const registro = await prisma.rol_permiso.findFirst({
+    where: {
+      fkrol,
+      permiso: { ruta: rutaPagina }
+    }
+  });
+
+  const tieneAcceso = !!registro;
+
+  // Guardar en caché
+  _cache.set(cacheKey, { tieneAcceso, expires: Date.now() + CACHE_TTL });
+
+  return tieneAcceso;
+};
+
+/**
  * Middleware factory.
  * @param {string} rutaPagina - Ruta de la página en la tabla permiso (ej: 'inventario')
  */
@@ -43,37 +78,9 @@ const verificarPermiso = (rutaPagina) => {
         return res.status(401).json({ success: false, message: 'No autenticado' });
       }
 
-      // Superadmin: acceso total (resuelto por nombre de rol, con cache)
-      if (await esRolSuperadmin(fkrol)) {
+      if (await tienePermiso(fkrol, rutaPagina)) {
         return next();
       }
-
-      // Revisar caché
-      const cacheKey = `${fkrol}:${rutaPagina}`;
-      const cached = _cache.get(cacheKey);
-      if (cached && cached.expires > Date.now()) {
-        if (cached.tieneAcceso) return next();
-        return res.status(403).json({
-          success: false,
-          message: 'No tienes permisos para realizar esta acción',
-          detalles: { pagina: rutaPagina }
-        });
-      }
-
-      // Consultar BD: ¿tiene este rol permiso para esta página?
-      const registro = await prisma.rol_permiso.findFirst({
-        where: {
-          fkrol,
-          permiso: { ruta: rutaPagina }
-        }
-      });
-
-      const tieneAcceso = !!registro;
-
-      // Guardar en caché
-      _cache.set(cacheKey, { tieneAcceso, expires: Date.now() + CACHE_TTL });
-
-      if (tieneAcceso) return next();
 
       return res.status(403).json({
         success: false,
@@ -102,4 +109,4 @@ const limpiarCacheRol = (fkrol) => {
   }
 };
 
-module.exports = { verificarPermiso, limpiarCachePermisos, limpiarCacheRol };
+module.exports = { verificarPermiso, tienePermiso, limpiarCachePermisos, limpiarCacheRol };

--- a/src/middlewares/checkRole.js
+++ b/src/middlewares/checkRole.js
@@ -6,11 +6,11 @@ let cacheTimestamp = null;
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutos
 
 /**
- * Obtener roles desde cache 
+ * Obtener roles desde cache
  */
 async function obtenerRolesParaMensajes() {
   const ahora = Date.now();
-  
+
   if (!rolesCache || !cacheTimestamp || (ahora - cacheTimestamp) > CACHE_DURATION) {
     rolesCache = await prisma.rol.findMany({
       where: { estado: 1 },
@@ -18,64 +18,15 @@ async function obtenerRolesParaMensajes() {
     });
     cacheTimestamp = ahora;
   }
-  
+
   return rolesCache;
 }
 
 /**
- * Middleware para verificar si el usuario tiene uno de los roles permitidos (por ID)
- * @param {...number} idsRolesPermitidos - IDs de los roles que pueden acceder
- * @returns {Function} Middleware de Express
- */
-const checkRole = (...idsRolesPermitidos) => {
-  return async (req, res, next) => {
-    try {
-      const fkrol = req.usuario.fkrol;
-
-      if (!fkrol) {
-        return res.status(403).json({
-          success: false,
-          message: 'No se pudo determinar el rol del usuario'
-        });
-      }
-
-      const tienePermiso = idsRolesPermitidos.includes(fkrol);
-
-      if (!tienePermiso) {
-        const roles = await obtenerRolesParaMensajes();
-        const rolUsuario = roles.find(r => r.idrol === fkrol);
-        const nombresPermitidos = idsRolesPermitidos.map(id => {
-          const rol = roles.find(r => r.idrol === id);
-          return rol ? rol.nombre : `ID: ${id}`;
-        });
-
-        return res.status(403).json({
-          success: false,
-          message: 'No tienes permisos para realizar esa acción',
-          detalles: {
-            tuRol: rolUsuario ? rolUsuario.nombre : `ID: ${fkrol}`,
-            rolesPermitidos: nombresPermitidos
-          }
-        });
-      }
-
-      next();
-    } catch (error) {
-      console.error('Error en checkRole:', error);
-      return res.status(500).json({
-        success: false,
-        message: 'Error al verificar permisos',
-        error: process.env.NODE_ENV === 'development' ? error.message : undefined
-      });
-    }
-  };
-};
-
-/**
- * Igual que checkRole, pero compara por NOMBRE de rol en vez de ID numerico.
- * El idrol de cada rol puede variar entre entornos (local/produccion), pero
- * el nombre es estable — por eso esta variante es la forma segura de
- * proteger rutas para roles especificos como "Administrador" o "Sistemas".
+ * Middleware para verificar si el usuario tiene uno de los roles permitidos, por NOMBRE.
+ * El idrol de cada rol puede variar entre entornos (local/produccion) e incluso entre
+ * momentos distintos del mismo entorno, pero el nombre es estable — por eso esta es la
+ * forma segura de proteger rutas para roles especificos como "Administrador" o "Sistemas".
  * @param {...string} nombresRolesPermitidos - Nombres de los roles que pueden acceder
  */
 const checkRoleByName = (...nombresRolesPermitidos) => {
@@ -117,6 +68,4 @@ const checkRoleByName = (...nombresRolesPermitidos) => {
   };
 };
 
-checkRole.byName = checkRoleByName;
-
-module.exports = checkRole;
+module.exports = { byName: checkRoleByName };

--- a/src/middlewares/validarReferido.js
+++ b/src/middlewares/validarReferido.js
@@ -273,7 +273,7 @@ validarDatosActualizacion: (req, res, next) => {
     try {
       const { fkclinica, comentario, rutadocumentoinicial, rutadocumentofinal } = req.body;
 
-      if (!fkclinica && comentario === undefined && !rutadocumentoinicial && !rutadocumentofinal) {
+      if (fkclinica === undefined && comentario === undefined && rutadocumentoinicial === undefined && rutadocumentofinal === undefined) {
         return res.status(400).json({
           ok: false,
           mensaje: 'Debe proporcionar al menos un campo para actualizar'

--- a/src/middlewares/validarReferido.js
+++ b/src/middlewares/validarReferido.js
@@ -1,5 +1,6 @@
 
 const { prisma } = require('../config/prisma');
+const { tienePermiso } = require('./checkPermiso');
 
 const validarReferido = {
 
@@ -149,7 +150,7 @@ validarPermisoConfirmar: async (req, res, next) => {
       include: { rol: true }
     });
 
-    const esAdmin = usuarioConRol.fkrol === 1 || usuarioConRol.fkrol === 7;
+    const esAdmin = await tienePermiso(usuarioConRol.fkrol, 'referidos-autorizar');
 
     if (referido.confirmacion2 === 0 && referido.confirmacion1 === 1) {
       if (!esAdmin) {
@@ -231,7 +232,7 @@ validarPermisoActualizar: async (req, res, next) => {
       include: { rol: true }
     });
 
-    const esAdmin = usuarioConRol.fkrol === 1 || usuarioConRol.fkrol === 7;
+    const esAdmin = await tienePermiso(usuarioConRol.fkrol, 'referidos-autorizar');
     const esCreador = referido.fkusuario === usuario.idusuario;
 
     const esEtapa4 = referido.confirmacion3 === 1 && referido.confirmacion4 === 0;

--- a/src/services/fileService.js
+++ b/src/services/fileService.js
@@ -111,6 +111,11 @@ class FileService {
       await fs.unlink(fullPath);
       return true;
     } catch (error) {
+      // Si el archivo ya no existe, el resultado que se buscaba (que no exista)
+      // ya se cumple: no es un error, para no dejar atascada la referencia en BD.
+      if (error.code === 'ENOENT') {
+        return true;
+      }
       console.error('Error eliminando archivo:', error);
       return false;
     }

--- a/src/services/referirService.js
+++ b/src/services/referirService.js
@@ -1,5 +1,6 @@
 
 const { prisma } = require('../config/prisma');
+const { tienePermiso } = require('../middlewares/checkPermiso');
 
 const referirService = {
 
@@ -270,7 +271,7 @@ const referirService = {
         include: { rol: true, clinica: true }
       });
 
-      const esAdmin = usuarioConRol.fkrol === 1 || usuarioConRol.fkrol === 7;
+      const esAdmin = await tienePermiso(usuarioConRol.fkrol, 'referidos-autorizar');
       const usuarioNombre = usuario.usuario;
       let campoActualizar = {};
       let mensaje = '';
@@ -394,7 +395,7 @@ const referirService = {
         include: { rol: true }
       });
 
-      const esAdmin = usuarioConRol.fkrol === 1 || usuarioConRol.fkrol === 7;
+      const esAdmin = await tienePermiso(usuarioConRol.fkrol, 'referidos-autorizar');
       const esCreador = referido.fkusuario === usuario.idusuario;
 
       const datosLimpios = Object.fromEntries(

--- a/src/services/reporteriaService.js
+++ b/src/services/reporteriaService.js
@@ -786,7 +786,7 @@ const reporteriaService = {
       const citasMes = await prisma.agenda.count({
         where: {
           fechaatencion: { gte: primerDiaMes },
-          estado: 1,
+          estado: { not: 0 }, // en agenda, estado es Pendiente/Confirmada/No se presento, no activo/inactivo; solo 0 es eliminada
           ...(esAdmin ? {} : { fkusuario: usuario.idusuario })
         }
       });
@@ -904,7 +904,10 @@ const reporteriaService = {
       // los tres, porque eso mostraría médicos que no tienen nada que ver con ese reporte.
       const fuentesPorContexto = {
         historial: () => prisma.detallehistorialclinico.findMany({ where: { estado: 1 }, select: { fkusuario: true }, distinct: ['fkusuario'] }),
-        agenda: () => prisma.agenda.findMany({ where: { estado: 1 }, select: { fkusuario: true }, distinct: ['fkusuario'] }),
+        // En agenda, "estado" no es activo/inactivo: 0=eliminada, 1=Pendiente, 2=Confirmada,
+        // 3=No se presento. Filtrar por estado:1 dejaba fuera a cualquier medico cuyas citas
+        // ya estuvieran confirmadas o marcadas como no-presento.
+        agenda: () => prisma.agenda.findMany({ where: { estado: { not: 0 } }, select: { fkusuario: true }, distinct: ['fkusuario'] }),
         referencias: () => prisma.detallereferirpaciente.findMany({ where: { estado: 1 }, select: { fkusuario: true }, distinct: ['fkusuario'] })
       };
 

--- a/src/services/reporteriaService.js
+++ b/src/services/reporteriaService.js
@@ -1104,16 +1104,8 @@ const reporteriaService = {
       const { nombrePaciente, cuiPaciente, desde, hasta, medico, programa, diagnostico, page, limit } = filtros;
       const skip = (page - 1) * limit;
 
-      const usuarioConRol = await prisma.usuario.findUnique({
-        where: { idusuario: usuario.idusuario },
-        include: { rol: true }
-      });
-
-      const esAdmin = usuarioConRol.rol.nombre.toLowerCase().includes('admin');
       const whereClause = { estado: 1 };
 
-      if (!esAdmin) whereClause.fkusuario = usuario.idusuario;
-      
       // Búsqueda por nombre del paciente
       if (nombrePaciente && nombrePaciente !== '') {
         whereClause.paciente = {
@@ -1154,7 +1146,7 @@ const reporteriaService = {
       const medicoNum = parseInt(medico);
       const programaNum = parseInt(programa);
 
-      if (!isNaN(medicoNum) && esAdmin) whereClause.fkusuario = medicoNum;
+      if (!isNaN(medicoNum)) whereClause.fkusuario = medicoNum;
       if (diagnostico && diagnostico !== '') whereClause.diagnosticotratamiento = { contains: diagnostico, mode: 'insensitive' };
 
       // Filtrar por programa al que pertenece el paciente (vía su expediente)
@@ -1312,16 +1304,8 @@ const reporteriaService = {
       const { nombrePaciente, cuiPaciente, desde, hasta, medico, transporte, estado, page, limit } = filtros;
       const skip = (page - 1) * limit;
 
-      const usuarioConRol = await prisma.usuario.findUnique({
-        where: { idusuario: usuario.idusuario },
-        include: { rol: true }
-      });
-
-      const esAdmin = usuarioConRol.rol.nombre.toLowerCase().includes('admin');
       const whereClause = {};
 
-      if (!esAdmin) whereClause.fkusuario = usuario.idusuario;
-      
       // Búsqueda por nombre del paciente
       if (nombrePaciente && nombrePaciente !== '') {
         whereClause.paciente = {
@@ -1354,7 +1338,7 @@ const reporteriaService = {
       const medicoNum = parseInt(medico);
       const transporteNum = parseInt(transporte);
       
-      if (!isNaN(medicoNum) && esAdmin) whereClause.fkusuario = medicoNum;
+      if (!isNaN(medicoNum)) whereClause.fkusuario = medicoNum;
       if (!isNaN(transporteNum)) whereClause.transporte = transporteNum;
       
       // Filtro de estado - manejo robusto de array
@@ -1446,22 +1430,10 @@ const reporteriaService = {
       const { nombrePaciente, cuiPaciente, tipo, estado, clinica, enviadoPor, confirmadoPor, desde, hasta, page, limit } = filtros;
       const skip = (page - 1) * limit;
 
-      const usuarioConRol = await prisma.usuario.findUnique({
-        where: { idusuario: usuario.idusuario },
-        include: { rol: true }
-      });
-
-      const esAdmin = usuarioConRol.rol.nombre.toLowerCase().includes('admin');
       const whereClause = { estado: 1 };
 
       if (tipo === 'enviadas') whereClause.fkusuario = usuario.idusuario;
       else if (tipo === 'recibidas') whereClause.fkusuariodestino = usuario.idusuario;
-      else if (!esAdmin) {
-        whereClause.OR = [
-          { fkusuario: usuario.idusuario },
-          { fkusuariodestino: usuario.idusuario }
-        ];
-      }
 
       if (estado === 'pendiente') whereClause.confirmacion4 = 0;
       else if (estado === 'proceso') {

--- a/src/services/usuarioService.js
+++ b/src/services/usuarioService.js
@@ -545,7 +545,8 @@ class UsuarioService {
             const usuario = await prismaClient.usuario.findUnique({
                 where:{
                     idusuario: parseInt(idusuario)
-                }
+                },
+                include: { rol: { select: { nombre: true } } }
             });
 
             if(!usuario){
@@ -562,10 +563,10 @@ class UsuarioService {
                 };
             }
 
-            if(Number(usuario.fkrol) === 1){
+            if(usuario.rol?.nombre === 'Administrador'){
                 const adminContador = await prismaClient.usuario.count({
                     where:{
-                        fkrol: 1,
+                        rol: { nombre: 'Administrador' },
                         estado: 1
                     }
                 });


### PR DESCRIPTION
El check hardcodeado `fkrol === 1 || fkrol === 7` asumia que el rol 7 era Auxiliar Administrativa, pero en produccion el rol 7 es Psicologo (el id de cada rol cambia entre entornos). Esto bloqueaba a Auxiliar Administrativa para aprobar fases 2/3, editar/eliminar referidos y gestionar documentos.

Se agrega tienePermiso() reutilizable en checkPermiso.js (sirve tanto en middlewares de Express como en services sin req/res) y se usa el nuevo permiso referidos-autorizar en los 4 lugares que tenian el hardcode (validarReferido.js x2, referirService.js x2) y en el frontend (referidos.component.ts). Incluye seed SQL que asigna el permiso por nombre de rol a Administrador, Sistemas y Auxiliar Administrativa.